### PR TITLE
Add firstLine regExp in client package definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 This changelog tracks changes starting from first public release.
+
+## Not released
+
+- Added `firstLine` element in extension definition so VSCode can recognise API Blueprint documents.

--- a/client/package.json
+++ b/client/package.json
@@ -62,7 +62,8 @@
         "extensions": [
           ".apib",
           ".apiblueprint"
-        ]
+        ],
+        "firstLine": "^[\uFEFF]?(((VERSION:( |\t)2)|(FORMAT:( |\t)(X-)?1A))([\n\r]{1,2}|$))"
       },
       {
         "id": "MSON",


### PR DESCRIPTION
The following PR will let VSCode set documents as API Blueprint when pasting code without specifying the extension.
